### PR TITLE
Renames from Maptos to Movement Aptos in MD files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ MOVEMENT => MAPTOS
   </pre>
 </div>
 
-# `movement-to-maptos`
+# `movement-to-movement-aptos`
 
-Tools, tests, and validation of migration from [`movement`](https://github.com/movementlabsxyz/movement) state to [`maptos`](https://github.com/movementlabsxyz/maptos-core).
+Tools, tests, and validation of migration from [`movement`](https://github.com/movementlabsxyz/movement) state to [`movement-aptos`](https://github.com/movementlabsxyz/movement-aptos-core).
 
 ## Getting started
 To run the migration check the [CLI documentation](./docs/cli/README.md).
@@ -17,9 +17,9 @@ We otherwise recommend reading the [tests](./tests/README.md) and working down i
 
 | Task | Description |
 |------|-------------|
-| [Upcoming Events](https://github.com/movementlabsxyz/movement-to-maptos/issues?q=is%3Aissue%20state%3Aopen%20label%3Apriority%3Ahigh%2Cpriority%3Amedium%20label%3Aevent) | High-priority `event` issues with planned completion dates. |
-| [Release Candidates](https://github.com/movementlabsxyz/movement-to-maptos/issues?q=is%3Aissue%20state%3Aopen%20label%3Arelease-candidate) | Feature-complete versions linked to events. |
-| [Features & Bugs](https://github.com/movementlabsxyz/movement-to-maptos/issues?q=is%3Aissue%20state%3Aopen%20label%3Afeature%2Cbug%20label%3Apriority%3Aurgent%2Cpriority%3Ahigh) | High-priority `feature` and `bug` issues. |
+| [Upcoming Events](https://github.com/movementlabsxyz/movement-to-movement-aptos/issues?q=is%3Aissue%20state%3Aopen%20label%3Apriority%3Ahigh%2Cpriority%3Amedium%20label%3Aevent) | High-priority `event` issues with planned completion dates. |
+| [Release Candidates](https://github.com/movementlabsxyz/movement-to-movement-aptos/issues?q=is%3Aissue%20state%3Aopen%20label%3Arelease-candidate) | Feature-complete versions linked to events. |
+| [Features & Bugs](https://github.com/movementlabsxyz/movement-to-movement-aptos/issues?q=is%3Aissue%20state%3Aopen%20label%3Afeature%2Cbug%20label%3Apriority%3Aurgent%2Cpriority%3Ahigh) | High-priority `feature` and `bug` issues. |
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) file for additional contribution guidelines.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,6 @@ The rigidity of this structure is to make it clear what the migration is accompl
 ## `Criterion`
 Tests are split into separate subdirectories which use their own `Criterion` types:
 
-- `e2e` wherein a `Criterion` is evaluated against a `MovementRestClient` and a `MaptosRestClient` respectively. 
-- `executor` wherein a `Criterion` is evaluated against a `MovementExecutor` and a `MaptosExecutor` respectively. 
+- `e2e` wherein a `Criterion` is evaluated against a `MovementRestClient` and a `MovementAptosRestClient` respectively. 
+- `executor` wherein a `Criterion` is evaluated against a `MovementExecutor` and a `MovementAptosExecutor` respectively. 
 


### PR DESCRIPTION
# Summary
Renames from Maptos to Movement Aptos in MD files, holdovers from #16 resolved. 