### PR TITLE
Adjust aptos-core rev with changed metric names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -818,14 +818,14 @@ dependencies = [
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
 ]
 
 [[package]]
@@ -853,11 +853,11 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
 ]
 
 [[package]]
@@ -900,14 +900,14 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "claims",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
 ]
 
 [[package]]
@@ -955,24 +955,24 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-bcs-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-build-info 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-mempool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-sdk 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-bcs-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-build-info 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-mempool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-sdk 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
  "fail",
@@ -981,7 +981,7 @@ dependencies = [
  "itertools 0.13.0",
  "mime",
  "mini-moka",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num_cpus",
  "once_cell",
  "paste",
@@ -1026,24 +1026,24 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-openapi 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-openapi 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "async-trait",
  "bcs 0.1.4",
  "bytes",
  "hex",
  "indoc",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "poem 3.1.9",
  "poem-openapi 5.1.13",
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "hex",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -1196,20 +1196,20 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "ambassador",
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-mvhashmap 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-mvhashmap 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-vm-environment",
- "aptos-vm-logging 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-vm-logging 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "arc-swap",
  "bcs 0.1.4",
  "bytes",
@@ -1219,10 +1219,10 @@ dependencies = [
  "derivative",
  "fail",
  "hashbrown 0.14.5",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.3",
@@ -1255,18 +1255,18 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "clap 4.5.36",
  "dashmap 5.5.3",
  "itertools 0.13.0",
  "jemallocator",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "rand 0.7.3",
  "rayon",
@@ -1286,7 +1286,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "futures",
  "rustversion",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "shadow-rs",
 ]
@@ -1326,14 +1326,14 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-package-builder 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-package-builder 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
 ]
 
@@ -1351,11 +1351,11 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "futures",
 ]
 
@@ -1389,10 +1389,10 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "lz4",
  "once_cell",
  "thiserror 1.0.69",
@@ -1432,16 +1432,16 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-secure-storage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-short-hex-str 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-temppath 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-secure-storage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-short-hex-str 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-temppath 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "arr_macro",
  "bcs 0.1.4",
  "byteorder",
@@ -1582,17 +1582,17 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-executor-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-short-hex-str 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-short-hex-str 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "derivative",
  "fail",
@@ -1675,11 +1675,11 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "aes-gcm",
  "anyhow",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "arbitrary",
  "ark-bn254",
  "ark-ec",
@@ -1739,7 +1739,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1854,26 +1854,26 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-accumulator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-db-indexer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-db-indexer-schemas 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-executor-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-jellyfish-merkle 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-rocksdb-options 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-schemadb 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-scratchpad 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-accumulator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-db-indexer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-db-indexer-schemas 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-jellyfish-merkle 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-rocksdb-options 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-schemadb 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-scratchpad 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "arc-swap",
  "arr_macro",
  "bcs 0.1.4",
@@ -1884,7 +1884,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "lru 0.7.8",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "rayon",
  "serde",
@@ -1916,22 +1916,22 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-db-indexer-schemas 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-rocksdb-options 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-schemadb 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-db-indexer-schemas 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-rocksdb-options 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-schemadb 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
  "dashmap 5.5.3",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
 ]
 
@@ -1952,13 +1952,13 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-schemadb 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-schemadb 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "byteorder",
  "proptest",
@@ -2000,12 +2000,12 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "blst",
  "blstrs",
@@ -2081,10 +2081,10 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "threadpool",
 ]
@@ -2117,14 +2117,14 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-channels 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-id-generator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-channels 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-id-generator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "futures",
  "serde",
  "thiserror 1.0.69",
@@ -2165,29 +2165,29 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-block-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-consensus-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-executor-service 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-executor-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-indexer-grpc-table-info 1.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-sdk 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-block-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-executor-service 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-indexer-grpc-table-info 1.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-sdk 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
  "fail",
  "itertools 0.13.0",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "rayon",
  "serde",
@@ -2226,23 +2226,23 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-block-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-block-partitioner 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-keygen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-language-e2e-tests 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-node-resource-metrics 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-push-metrics 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-secure-net 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-block-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-block-partitioner 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-keygen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-language-e2e-tests 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-node-resource-metrics 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-push-metrics 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-secure-net 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-transaction-simulation",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "clap 4.5.36",
  "crossbeam-channel",
@@ -2301,17 +2301,17 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-scratchpad 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-secure-net 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-scratchpad 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-secure-net 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "criterion",
  "derive_more 0.99.19",
@@ -2326,13 +2326,13 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-layered-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "ahash 0.8.11",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bitvec 1.0.1",
  "itertools 0.13.0",
  "once_cell",
@@ -2354,9 +2354,9 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "core_affinity",
  "libc",
  "num_cpus",
@@ -2491,18 +2491,18 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-sdk-builder 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-sdk-builder 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
@@ -2525,21 +2525,21 @@ dependencies = [
  "libsecp256k1",
  "log",
  "merlin",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-cli 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-cli 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "move-prover-lab",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num-traits",
  "once_cell",
  "rand 0.7.3",
@@ -2727,10 +2727,10 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "either",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
 ]
 
 [[package]]
@@ -2751,16 +2751,16 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
 ]
 
 [[package]]
@@ -2786,18 +2786,18 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "handlebars",
  "inferno",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "regex",
  "serde_json",
  "smallvec",
@@ -2819,12 +2819,12 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "paste",
  "rand 0.7.3",
 ]
@@ -2889,7 +2889,7 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80d
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 
 [[package]]
 name = "aptos-id-generator"
@@ -2899,7 +2899,7 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80d
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 
 [[package]]
 name = "aptos-indexer"
@@ -2974,22 +2974,22 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-api 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-indexer-grpc-utils 1.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-mempool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-api 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-indexer-grpc-utils 1.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-mempool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=bf4dd89677e6929ef21f898a7a4176514e606ebd)",
  "aptos-protos 1.3.1",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
  "chrono",
@@ -2997,7 +2997,7 @@ dependencies = [
  "hex",
  "hyper 0.14.32",
  "itertools 0.13.0",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "serde",
  "serde_json",
@@ -3063,21 +3063,21 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-api 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-db-indexer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-indexer-grpc-fullnode 1.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-indexer-grpc-utils 1.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-mempool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-api 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-db-indexer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-indexer-grpc-fullnode 1.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-indexer-grpc-utils 1.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-mempool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "flate2",
  "futures",
  "google-cloud-storage",
@@ -3126,10 +3126,10 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-protos 1.3.1",
  "aptos-transaction-filter",
  "async-trait",
@@ -3167,7 +3167,7 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80d
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 
 [[package]]
 name = "aptos-inspection-service"
@@ -3226,17 +3226,17 @@ dependencies = [
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "arr_macro",
  "bcs 0.1.4",
  "byteorder",
@@ -3313,10 +3313,10 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "rand 0.7.3",
 ]
 
@@ -3367,42 +3367,42 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-abstract-gas-usage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-block-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-cached-packages 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-profiling 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-keygen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-proptest-helpers 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-rest-client 0.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-temppath 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-abstract-gas-usage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-block-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-cached-packages 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-profiling 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-keygen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-proptest-helpers 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-rest-client 0.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-temppath 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-transaction-simulation",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-validator-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-validator-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-vm-environment",
- "aptos-vm-genesis 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-logging 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-vm-genesis 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-logging 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
  "claims",
  "goldenfile",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-compiler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-compiler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num_cpus",
  "once_cell",
  "petgraph 0.5.1",
@@ -3429,10 +3429,10 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "hex",
  "ledger-apdu",
  "ledger-transport-hid",
@@ -3452,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3486,10 +3486,10 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-log-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-log-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "backtrace",
  "chrono",
  "erased-serde",
@@ -3522,14 +3522,14 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
 ]
 
 [[package]]
@@ -3575,28 +3575,28 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-bounded-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-channels 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-consensus-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-event-notifications 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-mempool-notifications 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-netcore 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-network 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-peer-monitoring-service-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-short-hex-str 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-time-service 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-validator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-bounded-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-channels 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-event-notifications 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-mempool-notifications 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-netcore 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-network 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-peer-monitoring-service-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-short-hex-str 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-time-service 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-validator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "fail",
  "futures",
@@ -3628,9 +3628,9 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "async-trait",
  "futures",
  "serde",
@@ -3652,9 +3652,9 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bytes",
  "futures",
  "once_cell",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -3722,15 +3722,15 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "sha2 0.9.9",
  "sha3",
  "smallvec",
@@ -3776,20 +3776,20 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bytes",
  "claims",
  "crossbeam",
  "dashmap 5.5.3",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "serde",
 ]
 
@@ -3813,17 +3813,17 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "smallvec",
 ]
 
@@ -3847,11 +3847,11 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-memsocket 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-proxy 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-memsocket 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-proxy 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bytes",
  "futures",
  "pin-project",
@@ -3909,24 +3909,24 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-channels 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-compression 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-id-generator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-netcore 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-num-variants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-peer-monitoring-service-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-short-hex-str 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-time-service 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-channels 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-compression 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-id-generator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-netcore 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-num-variants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-peer-monitoring-service-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-short-hex-str 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-time-service 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "arc-swap",
  "async-trait",
  "bcs 0.1.4",
@@ -4140,12 +4140,12 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-build-info 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-build-info 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "cfg-if",
  "once_cell",
  "procfs",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "percent-encoding",
  "poem 3.1.9",
@@ -4215,13 +4215,13 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "itertools 0.13.0",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "tempfile",
 ]
 
@@ -4291,10 +4291,10 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "serde",
  "thiserror 1.0.69",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -4373,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "pbjson",
  "prost 0.13.5",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "ipnet",
 ]
@@ -4411,10 +4411,10 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "rand 0.7.3",
  "ureq",
  "url",
@@ -4498,16 +4498,16 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-vm-environment",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
 ]
 
 [[package]]
@@ -4536,18 +4536,18 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
  "hex",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -4568,9 +4568,9 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "rocksdb",
 ]
 
@@ -4586,7 +4586,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "rayon",
  "tokio",
@@ -4636,13 +4636,13 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "dunce",
  "once_cell",
  "proptest",
@@ -4672,14 +4672,14 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-drop-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bitvec 1.0.1",
  "dashmap 5.5.3",
  "itertools 0.13.0",
@@ -4713,21 +4713,21 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-cached-packages 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-ledger 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-rest-client 0.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-cached-packages 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-ledger 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-rest-client 0.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "base64 0.13.1",
  "bcs 0.1.4",
  "ed25519-dalek-bip32",
  "hex",
  "lazy_static",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest 0.11.27",
@@ -4757,14 +4757,14 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "clap 4.5.36",
  "heck 0.4.1",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "serde-generate",
  "serde-reflection",
@@ -4793,10 +4793,10 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-protos 1.3.1",
  "bcs 0.1.4",
  "crossbeam-channel",
@@ -4832,14 +4832,14 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-temppath 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-time-service 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vault-client 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-temppath 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-time-service 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vault-client 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "base64 0.13.1",
  "bcs 0.1.4",
  "chrono",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -4886,10 +4886,10 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "crossbeam",
  "rayon",
 ]
@@ -4959,16 +4959,16 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-experimental-layered-map",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-scratchpad 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-secure-net 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-scratchpad 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-secure-net 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "arr_macro",
  "bcs 0.1.4",
  "dashmap 5.5.3",
@@ -5113,17 +5113,17 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "better_any",
  "bytes",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "sha3",
  "smallvec",
 ]
@@ -5219,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -5241,9 +5241,9 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "enum_dispatch",
  "futures",
  "pin-project",
@@ -5254,7 +5254,7 @@ dependencies = [
 [[package]]
 name = "aptos-transaction-filter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "aptos-protos 1.3.1",
@@ -5272,17 +5272,17 @@ dependencies = [
 [[package]]
 name = "aptos-transaction-simulation"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-keygen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-genesis 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-keygen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-genesis 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "parking_lot 0.12.3",
  "proptest",
@@ -5349,14 +5349,14 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-dkg 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-dkg 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "arbitrary",
  "ark-bn254",
  "ark-ec",
@@ -5379,11 +5379,11 @@ dependencies = [
  "itertools 0.13.0",
  "jsonwebtoken 8.3.0",
  "lru 0.7.8",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num-bigint 0.3.3",
  "num-derive",
  "num-traits",
@@ -5440,21 +5440,21 @@ dependencies = [
 [[package]]
 name = "aptos-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-db 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-rest-client 0.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-api-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-db 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-rest-client 0.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "async-recursion",
  "async-trait",
  "bcs 0.1.4",
  "lru 0.7.8",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "tokio",
 ]
 
@@ -5490,9 +5490,9 @@ dependencies = [
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "base64 0.13.1",
  "chrono",
  "native-tls",
@@ -5557,30 +5557,30 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-block-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-block-partitioner 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-memory-usage-tracker 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-mvhashmap 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-table-natives 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-block-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-block-partitioner 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-meter 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-memory-usage-tracker 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-mvhashmap 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-table-natives 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-vm-environment",
- "aptos-vm-logging 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-vm-logging 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "ark-bn254",
  "ark-groth16",
  "bcs 0.1.4",
@@ -5592,11 +5592,11 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.13.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "move-vm-metrics",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num_cpus",
  "once_cell",
  "ouroboros",
@@ -5608,22 +5608,22 @@ dependencies = [
 [[package]]
 name = "aptos-vm-environment"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-table-natives 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-table-natives 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "sha3",
 ]
@@ -5652,22 +5652,22 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-cached-packages 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-cached-packages 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
  "claims",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "rand 0.7.3",
  "serde",
@@ -5691,13 +5691,13 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-speculative-state-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-metrics-core 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-speculative-state-helper 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "arc-swap",
  "once_cell",
  "serde",
@@ -5728,22 +5728,22 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "ambassador",
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "bcs 0.1.4",
  "bytes",
  "claims",
  "either",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "rand 0.7.3",
  "serde",
 ]
@@ -5766,20 +5766,20 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "aptos-vm-environment",
- "aptos-vm-logging 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-vm-logging 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "fail",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "rand 0.7.3",
 ]
 
@@ -11655,20 +11655,20 @@ dependencies = [
 [[package]]
 name = "legacy-move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.36",
  "codespan-reporting",
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "petgraph 0.6.5",
  "regex",
@@ -12299,7 +12299,7 @@ name = "migration-e2e-test-types"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "aptos-rest-client 0.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-rest-client 0.0.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "hex",
  "movement-client",
  "serde",
@@ -12360,10 +12360,10 @@ name = "migration-executor-test-types"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "aptos-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "chrono",
  "either",
  "hex",
@@ -12378,10 +12378,10 @@ name = "migration-executor-types"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "aptos-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "either",
  "hex",
  "maptos-opt-executor",
@@ -12512,17 +12512,17 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "heck 0.4.1",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "serde",
 ]
 
@@ -12544,13 +12544,13 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "backtrace",
  "indexmap 2.9.0",
- "move-bytecode-spec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-bytecode-spec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "ref-cast",
  "serde",
  "variant_count",
@@ -12564,7 +12564,7 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80d
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 
 [[package]]
 name = "move-bytecode-source-map"
@@ -12584,15 +12584,15 @@ dependencies = [
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "serde",
 ]
 
@@ -12609,7 +12609,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "once_cell",
  "quote",
@@ -12631,11 +12631,11 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "petgraph 0.6.5",
  "serde-reflection",
 ]
@@ -12657,12 +12657,12 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "fail",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "petgraph 0.6.5",
  "serde",
  "typed-arena",
@@ -12686,14 +12686,14 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "clap 4.5.36",
  "crossterm 0.26.1",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "regex",
  "tui",
 ]
@@ -12731,29 +12731,29 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "clap 4.5.36",
  "codespan-reporting",
  "colored",
  "legacy-move-compiler",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-unit-test 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-unit-test 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "tempfile",
 ]
@@ -12778,13 +12778,13 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "difference",
  "dirs-next",
  "hex",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num-bigint 0.3.3",
  "once_cell",
  "serde",
@@ -12852,9 +12852,9 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.36",
@@ -12866,17 +12866,17 @@ dependencies = [
  "itertools 0.13.0",
  "legacy-move-compiler",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num 0.4.3",
  "once_cell",
  "petgraph 0.6.5",
@@ -12911,7 +12911,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12956,18 +12956,18 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.36",
  "codespan",
  "colored",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "petgraph 0.6.5",
  "serde",
 ]
@@ -12992,18 +12992,18 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "clap 4.5.36",
  "colored",
  "legacy-move-compiler",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
 ]
 
 [[package]]
@@ -13028,7 +13028,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "clap 4.5.36",
@@ -13037,8 +13037,8 @@ dependencies = [
  "itertools 0.13.0",
  "legacy-move-compiler",
  "log",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "regex",
  "serde",
@@ -13059,12 +13059,12 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "serde",
 ]
 
@@ -13087,16 +13087,16 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.36",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-to-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "serde_json",
 ]
 
@@ -13121,18 +13121,18 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "codespan-reporting",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "ouroboros",
 ]
 
@@ -13152,14 +13152,14 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
 ]
 
 [[package]]
@@ -13178,12 +13178,12 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "serde",
 ]
@@ -13217,7 +13217,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "codespan",
@@ -13227,13 +13227,13 @@ dependencies = [
  "itertools 0.13.0",
  "legacy-move-compiler",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num 0.4.3",
  "num-traits",
  "once_cell",
@@ -13278,23 +13278,23 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "clap 4.5.36",
  "colored",
  "itertools 0.13.0",
  "legacy-move-compiler",
- "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "named-lock",
  "once_cell",
  "petgraph 0.6.5",
@@ -13339,7 +13339,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "atty",
@@ -13348,15 +13348,15 @@ dependencies = [
  "itertools 0.13.0",
  "legacy-move-compiler",
  "log",
- "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "serde",
  "simplelog",
@@ -13395,7 +13395,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13405,12 +13405,12 @@ dependencies = [
  "itertools 0.13.0",
  "legacy-move-compiler",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num 0.4.3",
  "once_cell",
  "pretty",
@@ -13441,33 +13441,33 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "anyhow",
  "codespan-reporting",
  "itertools 0.13.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "serde",
 ]
 
 [[package]]
 name = "move-prover-lab"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "chrono",
  "clap 4.5.36",
  "codespan-reporting",
  "itertools 0.13.0",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "plotters",
  "z3tracer",
 ]
@@ -13488,13 +13488,13 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "serde",
 ]
 
@@ -13520,18 +13520,18 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
- "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "anyhow",
  "codespan-reporting",
  "ethnum",
  "im",
  "itertools 0.13.0",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "num 0.4.3",
  "paste",
  "petgraph 0.6.5",
@@ -13565,20 +13565,20 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "hex",
  "legacy-move-compiler",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "sha2 0.9.9",
  "sha3",
  "smallvec",
@@ -13597,7 +13597,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "once_cell",
  "serde",
@@ -13621,14 +13621,14 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "better_any",
  "bytes",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "sha3",
  "smallvec",
 ]
@@ -13664,7 +13664,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "better_any",
@@ -13673,21 +13673,21 @@ dependencies = [
  "colored",
  "itertools 0.13.0",
  "legacy-move-compiler",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "rayon",
  "regex",
@@ -13696,7 +13696,7 @@ dependencies = [
 [[package]]
 name = "move-vm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -13729,7 +13729,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "ambassador",
  "better_any",
@@ -13739,11 +13739,11 @@ dependencies = [
  "hashbrown 0.14.5",
  "lazy_static",
  "lru 0.7.8",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "move-vm-metrics",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "parking_lot 0.12.3",
  "serde",
@@ -13770,16 +13770,16 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "anyhow",
  "bytes",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "once_cell",
  "serde",
 ]
@@ -13803,7 +13803,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301#6da77d982f82d6e41ace3fcd3651e208a9c1e301"
+source = "git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9#2941ee2b5876ab93cfb8010154c9466d7d593ed9"
 dependencies = [
  "ambassador",
  "bcs 0.1.4",
@@ -13814,8 +13814,8 @@ dependencies = [
  "derivative",
  "hashbrown 0.14.5",
  "itertools 0.13.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "parking_lot 0.12.3",
  "serde",
  "sha3",
@@ -14271,11 +14271,11 @@ name = "mtma-null-core"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-db 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
- "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=6da77d982f82d6e41ace3fcd3651e208a9c1e301)",
+ "aptos-config 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-db 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-executor 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-storage-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
+ "aptos-vm 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core.git?rev=2941ee2b5876ab93cfb8010154c9466d7d593ed9)",
  "chrono",
  "clap 4.5.36",
  "clap-markdown-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,14 +92,14 @@ maptos-opt-executor = { git = "https://github.com/movementlabsxyz/movement.git",
 movement-client = { git = "https://github.com/movementlabsxyz/movement.git", rev = "aa1ffed1a113441a65662792d15682ad52406108" }
 
 # maptos-core
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6da77d982f82d6e41ace3fcd3651e208a9c1e301" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6da77d982f82d6e41ace3fcd3651e208a9c1e301" }
-aptos-rest-client = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6da77d982f82d6e41ace3fcd3651e208a9c1e301" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6da77d982f82d6e41ace3fcd3651e208a9c1e301" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6da77d982f82d6e41ace3fcd3651e208a9c1e301" }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6da77d982f82d6e41ace3fcd3651e208a9c1e301" }
-aptos_schemadb = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6da77d982f82d6e41ace3fcd3651e208a9c1e301" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6da77d982f82d6e41ace3fcd3651e208a9c1e301" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2941ee2b5876ab93cfb8010154c9466d7d593ed9" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2941ee2b5876ab93cfb8010154c9466d7d593ed9" }
+aptos-rest-client = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2941ee2b5876ab93cfb8010154c9466d7d593ed9" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2941ee2b5876ab93cfb8010154c9466d7d593ed9" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2941ee2b5876ab93cfb8010154c9466d7d593ed9" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2941ee2b5876ab93cfb8010154c9466d7d593ed9" }
+aptos_schemadb = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2941ee2b5876ab93cfb8010154c9466d7d593ed9" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2941ee2b5876ab93cfb8010154c9466d7d593ed9" }
 # model checking and verification
 
 


### PR DESCRIPTION
# Summary
Use the `aptos-core` revision from https://github.com/movementlabsxyz/aptos-core/pull/157