### PR TITLE
fix: Intel nix build issues with _FORTIFY_SOURCE

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -98,5 +98,3 @@ rustflags = [
 check-revoke = false
 
 [env]
-CFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"
-CXXFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"

--- a/.github/workflows/nix-command.yml
+++ b/.github/workflows/nix-command.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
-          tool-cache: false
+          tool-cache: true
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nix-command.yml
+++ b/.github/workflows/nix-command.yml
@@ -21,16 +21,21 @@ jobs:
   run-command:
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - uses: actions/checkout@v4
-      
+
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-        
+
       - name: Enable Nix Flakes
         run: |
           mkdir -p ~/.config/nix
           echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
-          
+
       - name: Run Command in Nix Shell
         run: |
           echo "Running command: ${{ inputs.command }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         command:
           # cargo checks and tests
-          - cargo check --all-targets
+          # - cargo check --all-targets
           - cargo test
-          
+
     with:
       command: ${{ matrix.command }}
       nix_flake_path: '.' 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         command:
           # cargo checks and tests
-          # - cargo check --all-targets
+          - cargo check --all-targets
           - cargo test
 
     with:

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,8 @@
             ROCKSDB = pkgs.rocksdb;
             OPENSSL_DEV = pkgs.openssl.dev;
 
+            hardeningDisable = ["all"];
+
             buildInputs = with pkgs; [
               # rust toolchain
               (toolchain pkgs)

--- a/flake.nix
+++ b/flake.nix
@@ -100,9 +100,12 @@
             ] ++ sysDependencies ++ buildDependencies ++ testDependencies;
 
             LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib/";
+            CFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0";
+            CXXFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0";
 
             shellHook = ''
               #!/usr/bin/env ${pkgs.bash}
+
               # Export linker flags if on Darwin (macOS)
               if [[ "$(${pkgs.stdenv.hostPlatform.system})" =~ "darwin" ]]; then
                 export LDFLAGS="-L/opt/homebrew/opt/zlib/lib"

--- a/flake.nix
+++ b/flake.nix
@@ -100,8 +100,8 @@
             ] ++ sysDependencies ++ buildDependencies ++ testDependencies;
 
             LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib/";
-            CFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0";
-            CXXFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0";
+            #CFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0";
+            #CXXFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0";
 
             shellHook = ''
               #!/usr/bin/env ${pkgs.bash}

--- a/flake.nix
+++ b/flake.nix
@@ -92,8 +92,6 @@
             ROCKSDB = pkgs.rocksdb;
             OPENSSL_DEV = pkgs.openssl.dev;
 
-            hardeningDisable = ["all"];
-         
             buildInputs = with pkgs; [
               # rust toolchain
               (toolchain pkgs)

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,6 @@
           bzip2
           elfutils
           jemalloc
-          glibc
         ];
 
         testDependencies = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,8 @@
           docker-build = pkgs.mkShell {
             ROCKSDB = pkgs.rocksdb;
             OPENSSL_DEV = pkgs.openssl.dev;
+
+            hardeningDisable = ["all"];
          
             buildInputs = with pkgs; [
               # rust toolchain

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,7 @@
             ROCKSDB = pkgs.rocksdb;
             OPENSSL_DEV = pkgs.openssl.dev;
 
-            hardeningDisable = ["all"];
+            hardeningDisable = ["fortify"];
 
             buildInputs = with pkgs; [
               # rust toolchain
@@ -100,8 +100,6 @@
             ] ++ sysDependencies ++ buildDependencies ++ testDependencies;
 
             LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib/";
-            #CFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0";
-            #CXXFLAGS = "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0";
 
             shellHook = ''
               #!/usr/bin/env ${pkgs.bash}


### PR DESCRIPTION
- Disable hardening for `fortify` in the nix shell.
- Cleanup `.cargo/config.toml`.
- Free disk space on the GHA runner.
- Fix `glibc` build issue.
