### PR TITLE
fix: macos deps in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,6 @@
           pkg-config
           protobuf
           rustPlatform.bindgenHook
-          lld
           coreutils
           gcc
           rust
@@ -57,6 +56,8 @@
           postgresql
         ] ++ lib.optionals stdenv.isDarwin [
           fixDarwinDylibNames
+        ] ++ lib.optionals stdenv.isLinux [
+          lld
         ];
         
         sysDependencies = with pkgs; [] 
@@ -66,6 +67,7 @@
           frameworks.SystemConfiguration
           frameworks.AppKit
           libelf
+          bzip2 
         ] ++ lib.optionals stdenv.isLinux [
           udev
           systemd
@@ -120,6 +122,11 @@
                 export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)
                 export LDFLAGS="-L/opt/homebrew/opt/zlib/lib"
                 export CPPFLAGS="-I/opt/homebrew/opt/zlib/include"
+              fi
+
+              # Use lld only on Linux to avoid macOS linker error
+              if [[ "$(uname)" == "Linux" ]]; then
+                export RUSTFLAGS="-C link-arg=-fuse-ld=lld"
               fi
 
               # Add ./target/debug/* to PATH


### PR DESCRIPTION
I was getting a local build error with `cargo build -p movement` on the branch `l-monninger/movement-embedded-runner`:

```
  = note: ld64.lld: error: library not found for -lbz2
          ld64.lld: error: undefined symbol: BZ2_bzCompressInit
          >>> referenced by mem.rs:124 (src/mem.rs:124)
          >>>               /Users/andygmove/Downloads/repos/movement-migration/target/debug/deps/libbzip2-9270c2f43315dbcb.rlib(bzip2-9270c2f43315dbcb.bzip2.afd8c4a7827e7dec-cgu.0.rcgu.o):(symbol bzip2::mem::Compress::new::ha3b51860d4869327+0x150)
          
          ld64.lld: error: undefined symbol: BZ2_bzCompress
          >>> referenced by mem.rs:160 (src/mem.rs:160)
          >>>               /Users/andygmove/Downloads/repos/movement-migration/target/debug/deps/libbzip2-9270c2f43315dbcb.rlib(bzip2-9270c2f43315dbcb.bzip2.afd8c4a7827e7dec-cgu.0.rcgu.o):(symbol bzip2::mem::Compress::compress::he60a86a949d4c360+0x1d8)
          
          ld64.lld: error: undefined symbol: BZ2_bzCompressEnd
          >>> referenced by mem.rs:314 (src/mem.rs:314)
          >>>               /Users/andygmove/Downloads/repos/movement-migration/target/debug/deps/libbzip2-9270c2f43315dbcb.rlib(bzip2-9270c2f43315dbcb.bzip2.afd8c4a7827e7dec-cgu.0.rcgu.o):(symbol _$LT$bzip2..mem..DirCompress$u20$as$u20$bzip2..mem..Direction$GT$::destroy::h9c2d9228a6fb6408+0x14)
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile movement-core (build script) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

The changes in this PR fix the build for me on MacOS (Sonoma).

To test, run `nix develop && cargo build -p movement`