### PR TITLE
chore: type safe API for embedded Aptos runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8898,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "commander"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "anyhow",
  "futures",
@@ -12027,7 +12027,7 @@ dependencies = [
 [[package]]
 name = "include-dir"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "anyhow",
  "commander 0.1.0",
@@ -12041,7 +12041,7 @@ dependencies = [
 [[package]]
 name = "include-vendor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -12336,7 +12336,7 @@ dependencies = [
 [[package]]
 name = "jsonlvar"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "jsonlvar-core",
  "jsonlvar-macro",
@@ -12347,7 +12347,7 @@ dependencies = [
 [[package]]
 name = "jsonlvar-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "regex",
  "serde",
@@ -12358,7 +12358,7 @@ dependencies = [
 [[package]]
 name = "jsonlvar-macro"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12370,7 +12370,7 @@ dependencies = [
 [[package]]
 name = "jsonlvar-tokio"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "anyhow",
  "jsonlvar",
@@ -12579,7 +12579,7 @@ dependencies = [
 [[package]]
 name = "kestrel"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "futures",
  "kestrel-macro",
@@ -12592,7 +12592,7 @@ dependencies = [
 [[package]]
 name = "kestrel-macro"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -12605,7 +12605,7 @@ dependencies = [
 [[package]]
 name = "kestrel-process"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "commander 0.1.0",
  "jsonlvar",
@@ -12619,7 +12619,7 @@ dependencies = [
 [[package]]
 name = "kestrel-state"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -18285,7 +18285,7 @@ dependencies = [
 [[package]]
 name = "ready-docker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=8395e2dce55192269a41f5bacacedaf49555f875#8395e2dce55192269a41f5bacacedaf49555f875"
+source = "git+https://github.com/movementlabsxyz/kestrel.git?rev=96fa1a31088af992748c8dbe6b8fe4ccfba771fa#96fa1a31088af992748c8dbe6b8fe4ccfba771fa"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,12 +123,12 @@ secure-signer-loader = { git = "https://github.com/movementlabsxyz/secure-signin
 secure-signer-aws-kms = { git = "https://github.com/movementlabsxyz/secure-signing.git", rev = "f37eebd6d494d21b26b2faa44e1188de42ff1007" }
 
 # kestrel 
-kestrel = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "8395e2dce55192269a41f5bacacedaf49555f875" }
-jsonlvar = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "8395e2dce55192269a41f5bacacedaf49555f875" }
-commander = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "8395e2dce55192269a41f5bacacedaf49555f875" }
-include-dir = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "8395e2dce55192269a41f5bacacedaf49555f875" }
-include-vendor = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "8395e2dce55192269a41f5bacacedaf49555f875" }
-ready-docker = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "8395e2dce55192269a41f5bacacedaf49555f875" }
+kestrel = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "96fa1a31088af992748c8dbe6b8fe4ccfba771fa" }
+jsonlvar = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "96fa1a31088af992748c8dbe6b8fe4ccfba771fa" }
+commander = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "96fa1a31088af992748c8dbe6b8fe4ccfba771fa" }
+include-dir = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "96fa1a31088af992748c8dbe6b8fe4ccfba771fa" }
+include-vendor = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "96fa1a31088af992748c8dbe6b8fe4ccfba771fa" }
+ready-docker = { git = "https://github.com/movementlabsxyz/kestrel.git", rev = "96fa1a31088af992748c8dbe6b8fe4ccfba771fa" }
 
 # orfile
 orfile = { git = "https://github.com/movementlabsxyz/orfile.git", rev = "b49cb42495816fa00a1107be5bbf41aff3a8255d" }

--- a/checks/migrator/checks/sketchpad/src/example.rs
+++ b/checks/migrator/checks/sketchpad/src/example.rs
@@ -4,7 +4,7 @@ pub mod test {
 	use mtma_migrator_test_types::check::checked_migration;
 	use mtma_migrator_types::migrator::MovementMigrator;
 	use mtma_node_null_core::config::Config as MtmaNullConfig;
-	use mtma_node_test_types::prelude::{Prelude, PreludeError};
+	use mtma_node_test_types::prelude::Prelude;
 
 	#[tokio::test]
 	#[tracing_test::traced_test]

--- a/migration/util/migrator-types/src/migrator/movement_aptos_migrator.rs
+++ b/migration/util/migrator-types/src/migrator/movement_aptos_migrator.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use aptos_config::config::NodeConfig;
 use aptos_rest_client::Client as MovementAptosRestClient;
 use kestrel::WaitCondition;
-use movement_aptos_core::MovementAptos;
+use movement_aptos_core::{runtime, MovementAptos};
 use mtma_node_types::executor::MovementAptosNode;
 
 /// An enum supporting different types of runners.
@@ -12,7 +12,7 @@ use mtma_node_types::executor::MovementAptosNode;
 #[derive(Clone)]
 pub enum Runner {
 	/// [MovementAptos] runner.
-	MovementAptos(MovementAptos),
+	MovementAptos(MovementAptos<runtime::TokioTest>),
 }
 
 /// The [MovementAptos] migration struct as would be presented in the criterion.

--- a/util/movement-aptos/movement-aptos-core/src/movement_aptos.rs
+++ b/util/movement-aptos/movement-aptos-core/src/movement_aptos.rs
@@ -23,8 +23,8 @@ where
 	pub node_config: NodeConfig,
 	/// The path to the log file.
 	pub log_file: Option<PathBuf>,
-	/// Whether to create a global rayon pool.
-	pub create_global_rayon_pool: std::marker::PhantomData<R>,
+	/// The runtime for the Aptos node.
+	pub runtime: std::marker::PhantomData<R>,
 	/// The [MovementAptosRestApi] for the Aptos node.
 	pub rest_api: State<RestApi>,
 }
@@ -35,12 +35,7 @@ where
 {
 	/// If you have something that marks your ability to get a runtime, you can use this.
 	pub fn new(node_config: NodeConfig, log_file: Option<PathBuf>, _runtime: R) -> Self {
-		Self {
-			node_config,
-			log_file,
-			create_global_rayon_pool: std::marker::PhantomData,
-			rest_api: State::new(),
-		}
+		Self { node_config, log_file, runtime: std::marker::PhantomData, rest_api: State::new() }
 	}
 
 	/// Checks runtime availability and creates a new [MovementAptos].

--- a/util/movement-aptos/movement-aptos-core/src/movement_aptos/runtime.rs
+++ b/util/movement-aptos/movement-aptos-core/src/movement_aptos/runtime.rs
@@ -1,0 +1,90 @@
+use std::fmt::Debug;
+
+/// Errors thrown when attempting to use a runtime.
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+	#[error("encountered internal error while using Movement Aptos Runtime: {0}")]
+	Internal(#[source] Box<dyn std::error::Error + Send + Sync>),
+	#[error("requested Movement Aptos Runtime is unavailable: {0}")]
+	Unavailable(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Returns true if the current runtime is multithreaded.
+fn is_multithreaded_runtime() -> bool {
+	std::panic::catch_unwind(|| {
+		tokio::task::block_in_place(|| {});
+	})
+	.is_ok()
+}
+
+/// Trait for a runtime that can be used to run [MovementAptos].
+///
+/// A runtime knows statically whether it is multithreaded or not.
+pub trait Runtime: Sized + Clone + Debug + Send + Sync + 'static {
+	/// Try to create a new runtime.
+	fn try_new() -> Result<Self, RuntimeError>;
+
+	/// Returns whether to create a global rayon pool.
+	fn create_global_rayon_pool() -> bool;
+}
+
+/// Tokio test runtime.
+#[derive(Debug, Clone)]
+pub struct TokioTest;
+
+impl Runtime for TokioTest {
+	/// Try to create a new runtime.
+	fn try_new() -> Result<Self, RuntimeError> {
+		if !is_multithreaded_runtime() {
+			return Err(RuntimeError::Unavailable(Box::new(std::io::Error::new(
+				std::io::ErrorKind::Other,
+				"Tokio test runtime is not multithreaded use #[tokio::test(flavor = \"multi_thread\")] instead",
+			))));
+		}
+
+		Ok(Self)
+	}
+
+	/// Whether to create a global rayon pool.
+	fn create_global_rayon_pool() -> bool {
+		false
+	}
+}
+
+/// Native runtime refers to a runtime where the global rayon pool is created within the runner.
+#[derive(Debug, Clone)]
+pub struct Native;
+
+impl Runtime for Native {
+	/// Try to create a new runtime.
+	///
+	/// There are no restrictions on the surrounding environment here.
+	fn try_new() -> Result<Self, RuntimeError> {
+		Ok(Self)
+	}
+
+	/// Whether to create a global rayon pool.
+	fn create_global_rayon_pool() -> bool {
+		true
+	}
+}
+
+/// Delegated runtime refers to a runtime where the global rayon pool is created outside of the runner.
+///
+/// This is useful when we may be calling from other tasks, i.e., not at the main thread.
+#[derive(Debug, Clone)]
+pub struct Delegated;
+
+impl Runtime for Delegated {
+	/// Try to create a new runtime.
+	///
+	/// There are no restrictions on the surrounding environment here.
+	fn try_new() -> Result<Self, RuntimeError> {
+		Ok(Self)
+	}
+
+	/// Whether to create a global rayon pool.
+	fn create_global_rayon_pool() -> bool {
+		false
+	}
+}

--- a/util/movement-aptos/movement-aptos-core/src/movement_aptos/runtime/delegated.rs
+++ b/util/movement-aptos/movement-aptos-core/src/movement_aptos/runtime/delegated.rs
@@ -1,0 +1,21 @@
+use super::{Runtime, RuntimeError};
+
+/// Delegated runtime refers to a runtime where the global rayon pool is created outside of the runner.
+///
+/// This is useful when we may be calling from other tasks, i.e., not at the main thread.
+#[derive(Debug, Clone)]
+pub struct Delegated;
+
+impl Runtime for Delegated {
+	/// Try to create a new runtime.
+	///
+	/// There are no restrictions on the surrounding environment here.
+	fn try_new() -> Result<Self, RuntimeError> {
+		Ok(Self)
+	}
+
+	/// Whether to create a global rayon pool.
+	fn create_global_rayon_pool() -> bool {
+		false
+	}
+}

--- a/util/movement-aptos/movement-aptos-core/src/movement_aptos/runtime/native.rs
+++ b/util/movement-aptos/movement-aptos-core/src/movement_aptos/runtime/native.rs
@@ -1,0 +1,43 @@
+use super::{is_in_tokio_runtime, Runtime, RuntimeError};
+
+/// Native runtime refers to a runtime where the global rayon pool is created within the runner.
+#[derive(Debug, Clone)]
+pub struct Native;
+
+impl Runtime for Native {
+	/// Try to create a new runtime.
+	///
+	/// There are no restrictions on the surrounding environment here.
+	fn try_new() -> Result<Self, RuntimeError> {
+		if is_in_tokio_runtime() {
+			return Err(RuntimeError::Unavailable(Box::new(std::io::Error::new(
+				std::io::ErrorKind::Other,
+				"Native runtime is not available in a tokio runtime",
+			))));
+		}
+
+		Ok(Self)
+	}
+
+	/// Whether to create a global rayon pool.
+	fn create_global_rayon_pool() -> bool {
+		true
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn test_native_runtime_should_fail_in_tokio_runtime() -> Result<(), anyhow::Error> {
+		assert!(Native::try_new().is_err());
+		Ok(())
+	}
+
+	#[test]
+	fn test_native_runtime_should_succeed_outside_of_tokio_runtime() -> Result<(), anyhow::Error> {
+		assert!(Native::try_new().is_ok());
+		Ok(())
+	}
+}

--- a/util/movement-aptos/movement-aptos-core/src/movement_aptos/runtime/tokio_test.rs
+++ b/util/movement-aptos/movement-aptos-core/src/movement_aptos/runtime/tokio_test.rs
@@ -1,0 +1,47 @@
+use super::{is_in_tokio_runtime, is_multithreaded_runtime, Runtime, RuntimeError};
+
+/// Tokio test runtime.
+#[derive(Debug, Clone)]
+pub struct TokioTest;
+
+impl Runtime for TokioTest {
+	/// Try to create a new runtime.
+	fn try_new() -> Result<Self, RuntimeError> {
+		if !is_in_tokio_runtime() || !is_multithreaded_runtime() {
+			return Err(RuntimeError::Unavailable(Box::new(std::io::Error::new(
+				std::io::ErrorKind::Other,
+				"Tokio test runtime is not multithreaded use #[tokio::test(flavor = \"multi_thread\")] instead",
+			))));
+		}
+
+		Ok(Self)
+	}
+
+	/// Whether to create a global rayon pool.
+	fn create_global_rayon_pool() -> bool {
+		false
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn test_tokio_test_should_succeed_in_multi_thread() -> Result<(), anyhow::Error> {
+		TokioTest::try_new()?;
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn test_tokio_test_should_fail_in_single_thread() -> Result<(), anyhow::Error> {
+		assert!(TokioTest::try_new().is_err());
+		Ok(())
+	}
+
+	#[test]
+	fn test_tokio_test_should_fail_outside_of_tokio_test() -> Result<(), anyhow::Error> {
+		assert!(TokioTest::try_new().is_err());
+		Ok(())
+	}
+}

--- a/util/movement/movement-core/src/movement.rs
+++ b/util/movement/movement-core/src/movement.rs
@@ -303,7 +303,7 @@ impl Movement {
 	}
 }
 
-impl Drop for Movement {
+/*impl Drop for Movement {
 	fn drop(&mut self) {
 		// Get the real path of the workspace, following symlinks
 		if let Ok(real_path) = std::fs::canonicalize(self.workspace.get_workspace_path()) {
@@ -314,7 +314,7 @@ impl Drop for Movement {
 				.unwrap();
 		}
 	}
-}
+}*/
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# Summary 
Resolves #88 with a [type-safe API for the runtime](https://github.com/movementlabsxyz/movement-migration/blob/l-monninger/88/util/movement-aptos/movement-aptos-core/src/movement_aptos/runtime.rs). 

> [!WARNING]
> This currently still suffers from something similar to #86 which indicates this is on `kestrel::end` not deallocating something more than likely. I'm not sure what the difference is between `docker-compose` and the Aptos Node and `anvil` as was used with [`kestrel::end` in `ffs`](https://github.com/movementlabsxyz/ffs/blob/4ffcccb950611964d5929cdb300638ecaebfe3c4/network/mcr/components/eth/anvil/tests/basic/src/basic/mod.rs#L96). But, there seems to be something that is not quite being dropped in these environments. 
>
> Owing to the above, `cargo test` will run continuously. You should see the tests pass and then logging continue.