### PR TITLE
refactor(e2e): improve GlobalFeatureCheck

### DIFF
--- a/checks/e2e/citeria/matching-feature-flags/src/lib.rs
+++ b/checks/e2e/citeria/matching-feature-flags/src/lib.rs
@@ -1,28 +1,9 @@
 use migration_e2e_test_types::criterion::{
-	Criterion, CriterionError, Criterionish, MovementAptosE2eClient, MovementE2eClient,
+	CriterionError, Criterionish, MovementAptosE2eClient, MovementE2eClient,
 };
+use std::collections::HashSet;
 
-pub struct GlobalFeatureCheck {
-	aptos_client: MovementAptosE2eClient,
-}
-
-impl GlobalFeatureCheck {
-	pub fn new(aptos_client: MovementAptosE2eClient) -> Self {
-		Self { aptos_client }
-	}
-
-	pub fn criterion(aptos_client: MovementAptosE2eClient) -> Criterion<Self> {
-		Criterion::new(Self { aptos_client })
-	}
-
-	pub fn aptos_client(&self) -> &MovementAptosE2eClient {
-		&self.aptos_client
-	}
-
-	pub fn aptos_client_mut(&mut self) -> &mut MovementAptosE2eClient {
-		&mut self.aptos_client
-	}
-}
+pub struct GlobalFeatureCheck;
 
 impl Criterionish for GlobalFeatureCheck {
 	async fn satisfies(
@@ -30,55 +11,45 @@ impl Criterionish for GlobalFeatureCheck {
 		movement_e2e_client: &MovementE2eClient,
 		movement_aptos_e2e_client: &MovementAptosE2eClient,
 	) -> Result<(), CriterionError> {
-		let mut mismatches = vec![];
-		let unique_features = [73];
+		let mut errors = vec![];
+		let expected_active = HashSet::from([73]);
+		let expected_inactive = HashSet::<u64>::new();
 
 		for feature_id in 1u64..=100 {
 			// Check feature for Aptos executor
-			let aptos_enabled = self
-				.aptos_client()
+			let aptos_active = movement_aptos_e2e_client
 				.check_feature_enabled(feature_id)
 				.map_err(|e| CriterionError::Internal(e.into()))?;
 
 			// Check feature for Maptos executor
-			let maptos_enabled = movement_aptos_e2e_client
+			let maptos_active = movement_e2e_client
 				.check_feature_enabled(feature_id)
 				.map_err(|e| CriterionError::Internal(e.into()))?;
 
-			if !unique_features.contains(&feature_id) {
-				if !maptos_enabled {
-					return Err(CriterionError::Unsatisfied(
-						format!("Feature {}: Maptos={} — not enabled", feature_id, maptos_enabled)
-							.into(),
+			if !expected_active.contains(&feature_id) {
+				if !maptos_active {
+					errors.push(format!(
+						"Feature {}: Aptos={}, Maptos={} — expected to be active",
+						feature_id, aptos_active, maptos_active
 					));
 				}
-
-				if aptos_enabled != maptos_enabled {
-					return Err(CriterionError::Unsatisfied(
-						format!(
-							"Feature {}: Aptos={}, Maptos={} — mismatch",
-							feature_id, aptos_enabled, maptos_enabled
-						)
-						.into(),
+			} else if !expected_inactive.contains(&feature_id) {
+				if maptos_active {
+					errors.push(format!(
+						"Feature {}: Aptos={}, Maptos={} — expected to be inactive",
+						feature_id, aptos_active, maptos_active
 					));
 				}
-			}
-
-			// Check feature for Movement executor — WARN on differences
-			let movement_enabled = movement_e2e_client
-				.check_feature_enabled(feature_id)
-				.map_err(|e| CriterionError::Internal(e.into()))?;
-
-			if movement_enabled != aptos_enabled {
-				mismatches.push(format!(
-					"Feature {} differs in Movement (Movement={}, Aptos={})",
-					feature_id, movement_enabled, aptos_enabled
+			} else if aptos_active != maptos_active {
+				errors.push(format!(
+					"Feature {}: Aptos={}, Maptos={} — expected to match",
+					feature_id, aptos_active, maptos_active
 				));
 			}
 		}
 
-		for warning in mismatches {
-			eprintln!("Warning: {}", warning);
+		if !errors.is_empty() {
+			return Err(CriterionError::Unsatisfied(errors.join("\n").into()));
 		}
 
 		Ok(())


### PR DESCRIPTION
# Summary
Resolves #66

# Changes
- Check only Aptos vs. Maptos feature flags.
- Check all features before returning an error.