### PR TITLE
fix: bad known listen url

### DIFF
--- a/checks/migrator/checks/pre-l1-merge/src/pre_l1_merge.rs
+++ b/checks/migrator/checks/pre-l1-merge/src/pre_l1_merge.rs
@@ -55,15 +55,7 @@ pub mod test {
 				.wait_for_rest_api_url(tokio::time::Duration::from_secs(600))
 				.await?;
 			info!("REST API URL: {}", rest_api_url);
-			// Wait for the REST API URL to be on port 30731
-			while !rest_api_url.contains(":30731") {
-				info!("Waiting for REST API to be on port 30731, current URL: {}", rest_api_url);
-				tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-				rest_api_url = movement_migrator
-					.wait_for_rest_api_url(tokio::time::Duration::from_secs(600))
-					.await?;
-				info!("REST API URL: {}", rest_api_url);
-			}
+
 			movement_migrator
 				.wait_for_rest_client_ready(tokio::time::Duration::from_secs(600))
 				.await

--- a/util/movement/core/src/movement/rest_api.rs
+++ b/util/movement/core/src/movement/rest_api.rs
@@ -63,7 +63,7 @@ impl CustomProcessor<RestApi> for ParseRestApi {
 				.trim();
 
 			// match line of the following form to extract the rest api listen url: movement-full-node | 2025-05-06T08:49:06.205999Z  INFO poem::server: listening addr=socket://0.0.0.0:30731
-			if let Some(captures) =
+			if let Some(_captures) =
 				regex::Regex::new(r#"movement-full-node.*socket://([^:]+):(\d+)"#)
 					.map_err(|e| FulfillError::Internal(format!("invalid regex: {e}").into()))?
 					.captures(&trimmed)
@@ -105,9 +105,7 @@ impl CustomProcessor<RestApi> for ParseRestApi {
 							}
 						}
 
-						return Ok(Some(RestApi {
-							listen_url: format!("http://{}:{}", &captures[1], &captures[2]),
-						}));
+						return Ok(Some(RestApi { listen_url: self.known_listen_url.clone() }));
 					}
 				}
 			}


### PR DESCRIPTION
# Summary
#142 properly checks the configured listen url, but it still used captures to return the value which can cause issues. This always returns the known config value if the polling succeeds. 