### PR TITLE
feat: add `--help` checks for containers

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -24,6 +24,12 @@ jobs:
         architecture: [x86_64, arm64]        
     runs-on: ${{ matrix.architecture == 'x86_64' && 'buildjet-16vcpu-ubuntu-2204' || 'buildjet-16vcpu-ubuntu-2204-arm' }}
     steps:
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          
       - name: Checkout repository
         uses: actions/checkout@v4
         with: 

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -22,14 +22,14 @@ jobs:
     strategy:
       matrix:
         architecture: [x86_64, arm64]        
-    runs-on: ${{ matrix.architecture == 'x86_64' && 'buildjet-16vcpu-ubuntu-2204' || 'buildjet-16vcpu-ubuntu-2204-arm' }}
+    runs-on: ${{ matrix.architecture == 'x86_64' && 'buildjet-32vcpu-ubuntu-2204' || 'buildjet-32vcpu-ubuntu-2204-arm' }}
     steps:
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
-          
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with: 

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         architecture: [x86_64, arm64]        
-    runs-on: ${{ matrix.architecture == 'x86_64' && 'buildjet-32vcpu-ubuntu-2204' || 'buildjet-32vcpu-ubuntu-2204-arm' }}
+    runs-on: ${{ matrix.architecture == 'x86_64' && 'movement-runner' || 'movement-runner-arm' }}
     steps:
 
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -73,4 +73,4 @@ jobs:
         ]
       github_sha: ${{ github.sha }}
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      INFRA_GH_TOKEN: ${{ secrets.INFRA_GH_TOKEN }}

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -50,3 +50,27 @@ jobs:
           - mtma
     with:
       container_name: ${{ matrix.container_name }}
+
+  run-container-checks:
+    needs: 
+      - build-push-checked-containers
+    uses: ./.github/workflows/container-check.yml
+    with:
+      container_checks: |
+        [
+          {
+            "container": "movement",
+            "command": "--help"
+          },
+          {
+            "container": "movement-aptos",
+            "command": "--help"
+          },
+          {
+            "container": "mtma",
+            "command": "--help"
+          }
+        ]
+      github_sha: ${{ github.sha }}
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -53,7 +53,7 @@ jobs:
 
   run-container-checks:
     needs: 
-      - build-push-checked-containers
+      - build-push-checked-manifest
     uses: ./.github/workflows/container-check.yml
     with:
       container_checks: |

--- a/.github/workflows/container-check.yml
+++ b/.github/workflows/container-check.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   run-container-checks:
-    runs-on: ubuntu-latest
+    runs-on: movement-runner
     steps:
       - name: Parse container checks
         id: parse-checks

--- a/.github/workflows/container-check.yml
+++ b/.github/workflows/container-check.yml
@@ -22,7 +22,7 @@ on:
         default: '${{ github.repository_owner }}'
         description: 'Container registry owner'
     secrets:
-      GITHUB_TOKEN:
+      INFRA_GH_TOKEN:
         required: true
         description: 'GitHub token for registry access'
 
@@ -40,7 +40,7 @@ jobs:
       - name: Run container checks
         run: |
           # Login to container registry
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ inputs.registry }} -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.INFRA_GH_TOKEN }}" | docker login ${{ inputs.registry }} -u ${{ github.actor }} --password-stdin
           
           # Read and parse the checks
           checks=$(cat <<'EOF'

--- a/.github/workflows/container-check.yml
+++ b/.github/workflows/container-check.yml
@@ -60,7 +60,10 @@ jobs:
             docker pull ${{ inputs.registry }}/${{ inputs.registry_owner }}/$container:${{ inputs.github_sha }}
             
             # Run the check
-            if ! docker run --rm ${{ inputs.registry }}/${{ inputs.registry_owner }}/$container:${{ inputs.github_sha }} $command; then
+            if ! docker run --rm \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -e DOCKER_HOST=unix:///var/run/docker.sock \
+              ${{ inputs.registry }}/${{ inputs.registry_owner }}/$container:${{ inputs.github_sha }} $command; then
               echo "Check failed for container: $container"
               exit 1
             fi

--- a/.github/workflows/container-check.yml
+++ b/.github/workflows/container-check.yml
@@ -1,0 +1,69 @@
+name: Container Check Runner
+
+on:
+  workflow_call:
+    inputs:
+      container_checks:
+        required: true
+        type: string
+        description: 'JSON array of container checks in format [{"container": "container-name", "command": "command-to-run"}]'
+      github_sha:
+        required: true
+        type: string
+        description: 'The GITHUB_SHA to check against'
+      registry:
+        required: false
+        type: string
+        default: 'ghcr.io'
+        description: 'Container registry to use'
+      registry_owner:
+        required: false
+        type: string
+        default: '${{ github.repository_owner }}'
+        description: 'Container registry owner'
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+        description: 'GitHub token for registry access'
+
+jobs:
+  run-container-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse container checks
+        id: parse-checks
+        run: |
+          echo "checks<<EOF" >> $GITHUB_OUTPUT
+          echo '${{ inputs.container_checks }}' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Run container checks
+        run: |
+          # Login to container registry
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ inputs.registry }} -u ${{ github.actor }} --password-stdin
+          
+          # Read and parse the checks
+          checks=$(cat <<'EOF'
+          ${{ steps.parse-checks.outputs.checks }}
+          EOF
+          )
+          
+          # Run each check
+          echo "$checks" | jq -c '.[]' | while read -r check; do
+            container=$(echo "$check" | jq -r '.container')
+            command=$(echo "$check" | jq -r '.command')
+            
+            echo "Running check for container: $container"
+            echo "Command: $command"
+            
+            # Pull the container
+            docker pull ${{ inputs.registry }}/${{ inputs.registry_owner }}/$container:${{ inputs.github_sha }}
+            
+            # Run the check
+            if ! docker run --rm ${{ inputs.registry }}/${{ inputs.registry_owner }}/$container:${{ inputs.github_sha }} $command; then
+              echo "Check failed for container: $container"
+              exit 1
+            fi
+            
+            echo "Check passed for container: $container"
+          done 

--- a/.github/workflows/container-check.yml
+++ b/.github/workflows/container-check.yml
@@ -53,7 +53,7 @@ jobs:
             container=$(echo "$check" | jq -r '.container')
             command=$(echo "$check" | jq -r '.command')
             
-            echo "Running check for container: $container"
+            echo "Running check for container: $container (${{ inputs.registry }}/${{ inputs.registry_owner }}/$container:${{ inputs.github_sha }})"
             echo "Command: $command"
             
             # Pull the container

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15778,22 +15778,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mtma-migrator-matching-feature-flags"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "kestrel",
- "mtma-migrator-test-matching-feature-flags-criterion",
- "mtma-migrator-test-types",
- "mtma-migrator-types",
- "mtma-node-null-core",
- "mtma-node-test-types",
- "tokio",
- "tracing",
- "tracing-test",
-]
-
-[[package]]
 name = "mtma-migrator-checks-pre-l1-merge"
 version = "0.0.1"
 dependencies = [
@@ -15815,6 +15799,22 @@ dependencies = [
  "mtma-types",
  "rand 0.7.3",
  "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-test",
+]
+
+[[package]]
+name = "mtma-migrator-matching-feature-flags"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "kestrel",
+ "mtma-migrator-test-matching-feature-flags-criterion",
+ "mtma-migrator-test-types",
+ "mtma-migrator-types",
+ "mtma-node-null-core",
+ "mtma-node-test-types",
  "tokio",
  "tracing",
  "tracing-test",

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -29,6 +29,7 @@ RUN adduser -u 1000 -D -s /bin/bash movement
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/movement /app/movement
 COPY --from=builder /tmp/runtime/nix/store /nix/store
+COPY --dereference --from=builder /nix/store/ /nix/store/
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -21,6 +21,8 @@ RUN rust_binary="./target/release/movement"; dest_dir="/tmp/runtime"; \
 
 FROM alpine:3.22.0
 
+RUN apk add --no-cache bash
+
 # Create non-root user
 RUN adduser -u 1000 -D -s /bin/bash movement
 

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -9,9 +9,27 @@ WORKDIR /tmp/build
 # Set build to docker to skip the podman initilization while opening the flake
 ENV BUILD=docker
 
-# Build the Rust application
 RUN nix --extra-experimental-features "nix-command flakes" \
-        develop .#docker-build --command bash -c "cargo build --release --bin movement"
+        develop --command bash -c "mkdir -p  /tmp/executables"
+
+# Copy celestia-appd to /tmp/executables
+RUN nix --extra-experimental-features "nix-command flakes" \
+        develop --command bash -c "cp \$(which podman) /tmp/executables/podman"
+
+        # Build the Rust application
+RUN nix --extra-experimental-features "nix-command flakes" \
+        develop .#docker-build --command bash -c "cargo build --release -p movement"
+
+
+RUN rust_binary="./target/release/movement"; dest_dir="/tmp/runtime"; \
+    mkdir -p "$dest_dir"; ldd "$rust_binary" | awk '{print $3}' | \
+    grep '^/' | xargs -I {} dirname {} | sort | uniq | xargs -I {} \
+    bash -c 'mkdir -p "$0/$1" && rsync -a --copy-links "$1/" "$0/$1/"' "$dest_dir" {}
+
+RUN rust_binary="/tmp/executables/podman"; dest_dir="/tmp/runtime"; \
+    mkdir -p "$dest_dir"; ldd "$rust_binary" | awk '{print $3}' | \
+    grep '^/' | xargs -I {} dirname {} | sort | uniq | xargs -I {} \
+    bash -c 'mkdir -p "$0/$1" && rsync -a --copy-links "$1/" "$0/$1/"' "$dest_dir" {}
 
 FROM alpine:3.22.0
 
@@ -22,7 +40,10 @@ RUN adduser -u 1000 -D -s /bin/bash movement
 
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/movement /app/movement
-COPY --from=builder /nix/store /nix/store/
+COPY --from=builder /nix/store /nix/store
+
+# copy executables
+COPY --from=builder /tmp/executables/podman /usr/local/bin/podman
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -13,12 +13,6 @@ ENV BUILD=docker
 RUN nix --extra-experimental-features "nix-command flakes" \
         develop .#docker-build --command bash -c "cargo build --release --bin movement"
 
-RUN rust_binary="./target/release/movement"; dest_dir="/tmp/runtime"; \
-    mkdir -p "$dest_dir"; ldd "$rust_binary" | awk '{print $3}' | \
-    grep '^/' | xargs -I {} dirname {} | sort | uniq | xargs -I {} \
-    bash -c 'mkdir -p "$0/$1" && rsync -a --copy-links "$1/" "$0/$1/"' "$dest_dir" {}
-
-
 FROM alpine:3.22.0
 
 RUN apk add --no-cache bash
@@ -28,8 +22,7 @@ RUN adduser -u 1000 -D -s /bin/bash movement
 
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/movement /app/movement
-COPY --from=builder /tmp/runtime/nix/store /nix/store
-COPY --from=builder /nix/store/ /nix-bin/store/
+COPY --from=builder /nix/store /nix/store/
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -27,6 +27,7 @@ RUN adduser -u 1000 -D -s /bin/bash movement
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/movement /app/movement
 COPY --from=builder /tmp/runtime/nix/store /nix/store
+COPY --from=builder /tmp/runtime/nix/var/nix/profiles/default/bin /nix/var/nix/profiles/default/bin
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -39,8 +39,8 @@ RUN mkdir -p /run/user/1000/podman && \
     chown -R movement:movement /run/user/1000 /app /nix
 
 # Copy runtime bootstrap script
-COPY docker/build/movement/entry.sh /app/entry.sh
-RUN chmod +x /app/entry.sh
+COPY docker/build/mtma/entry.sh /app/entry.sh
+RUN chmod +x /app/entry.sh && chown mtma:mtma /app/entry.sh
 
 # Switch to non-root user
 USER movement

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -39,8 +39,8 @@ RUN mkdir -p /run/user/1000/podman && \
     chown -R movement:movement /run/user/1000 /app /nix
 
 # Copy runtime bootstrap script
-COPY docker/build/mtma/entry.sh /app/entry.sh
-RUN chmod +x /app/entry.sh && chown mtma:mtma /app/entry.sh
+COPY docker/build/movement/entry.sh /app/entry.sh
+RUN chmod +x /app/entry.sh && chown movement:movement /app/entry.sh
 
 # Switch to non-root user
 USER movement

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -29,7 +29,6 @@ RUN adduser -u 1000 -D -s /bin/bash movement
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/movement /app/movement
 COPY --from=builder /tmp/runtime/nix/store /nix/store
-COPY --from=builder /tmp/runtime/nix/var/nix/profiles/default/bin /nix/var/nix/profiles/default/bin
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -29,7 +29,7 @@ RUN adduser -u 1000 -D -s /bin/bash movement
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/movement /app/movement
 COPY --from=builder /tmp/runtime/nix/store /nix/store
-COPY --dereference --from=builder /nix/store/ /nix/store/
+COPY --from=builder /nix/store/ /nix/store/
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -29,7 +29,7 @@ RUN adduser -u 1000 -D -s /bin/bash movement
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/movement /app/movement
 COPY --from=builder /tmp/runtime/nix/store /nix/store
-COPY --from=builder /nix/store/ /nix/store/
+COPY --from=builder /nix/store/ /nix-bin/store/
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -18,7 +18,7 @@ RUN nix --extra-experimental-features "nix-command flakes" \
 
         # Build the Rust application
 RUN nix --extra-experimental-features "nix-command flakes" \
-        develop .#docker-build --command bash -c "cargo build --release -p movement"
+        develop .#docker-build --command bash -c "cargo build --release --bin movement"
 
 
 RUN rust_binary="./target/release/movement"; dest_dir="/tmp/runtime"; \

--- a/docker/build/movement/Dockerfile
+++ b/docker/build/movement/Dockerfile
@@ -12,11 +12,13 @@ ENV BUILD=docker
 RUN nix --extra-experimental-features "nix-command flakes" \
         develop --command bash -c "mkdir -p  /tmp/executables"
 
-# Copy celestia-appd to /tmp/executables
 RUN nix --extra-experimental-features "nix-command flakes" \
         develop --command bash -c "cp \$(which podman) /tmp/executables/podman"
 
-        # Build the Rust application
+RUN nix --extra-experimental-features "nix-command flakes" \
+        develop --command bash -c "cp \$(which docker) /tmp/executables/docker"
+
+# Build the Rust application
 RUN nix --extra-experimental-features "nix-command flakes" \
         develop .#docker-build --command bash -c "cargo build --release --bin movement"
 
@@ -44,15 +46,15 @@ COPY --from=builder /nix/store /nix/store
 
 # copy executables
 COPY --from=builder /tmp/executables/podman /usr/local/bin/podman
+COPY --from=builder /tmp/executables/docker /usr/local/bin/docker
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"
 ENV XDG_RUNTIME_DIR="/run/user/1000"
 ENV TMPDIR="/tmp"
-ENV DOCKER_HOST="unix:///run/user/1000/podman/podman-machine-default-api.sock"
 
 # Create required runtime dirs with proper ownership
-RUN mkdir -p /run/user/1000/podman && \
+RUN mkdir -p /run/user/1000 && \
     chown -R movement:movement /run/user/1000 /app /nix
 
 # Copy runtime bootstrap script

--- a/docker/build/movement/entry.sh
+++ b/docker/build/movement/entry.sh
@@ -3,9 +3,9 @@
 set -e
 
 echo "Debugging nix store..."
-ls -al /nix-bin/store
-find /nix-bin/store -type d -path '*/bin' | paste -sd: -
-export PATH="/nix-bin/store:$(find /nix-bin/store -type d -path '*/bin' | paste -sd: -):$PATH"
+ls -al /nix/store
+find /nix/store -type d -path '*/bin' | paste -sd: -
+export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
 echo "PATH: $PATH"
 
 # Start Podman machine if not running

--- a/docker/build/movement/entry.sh
+++ b/docker/build/movement/entry.sh
@@ -22,43 +22,6 @@ fi
 
 echo "DOCKER_HOST is set to: $DOCKER_HOST"
 
-# Extract socket path from DOCKER_HOST
-if [[ "$DOCKER_HOST" == unix://* ]]; then
-    SOCKET_PATH="${DOCKER_HOST#unix://}"
-    echo "Socket path: $SOCKET_PATH"
-    
-    # Check if socket file exists and is accessible
-    if [ ! -S "$SOCKET_PATH" ]; then
-        echo "ERROR: Socket file does not exist or is not accessible: $SOCKET_PATH"
-        echo "Please ensure the container runtime socket is available and mounted"
-        exit 1
-    fi
-    
-    # Test socket connectivity by trying to list containers
-    echo "Testing socket connectivity..."
-    if command -v docker &> /dev/null; then
-        if docker ps &> /dev/null; then
-            echo "✓ Docker socket is working - can list containers"
-        else
-            echo "✗ Docker socket test failed"
-            exit 1
-        fi
-    elif command -v podman &> /dev/null; then
-        if podman ps &> /dev/null; then
-            echo "✓ Podman socket is working - can list containers"
-        else
-            echo "✗ Podman socket test failed"
-            exit 1
-        fi
-    else
-        echo "WARNING: Neither docker nor podman command found, but socket exists"
-        echo "Socket validation passed, but container management may not work"
-    fi
-else
-    echo "WARNING: DOCKER_HOST is not a unix socket, container management may not work"
-    echo "Current DOCKER_HOST: $DOCKER_HOST"
-fi
-
 echo "Container management setup validated successfully!"
 echo "Launching application..."
 exec /app/movement "$@"

--- a/docker/build/movement/entry.sh
+++ b/docker/build/movement/entry.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+find /nix/store -type d -path '*/bin' | paste -sd: -
+export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
+
 # Start Podman machine if not running
 if ! podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null | grep -q 'running'; then
     echo "Starting podman machine..."

--- a/docker/build/movement/entry.sh
+++ b/docker/build/movement/entry.sh
@@ -2,8 +2,11 @@
 
 set -e
 
+echo "Debugging nix store..."
+ls -al /nix/store
 find /nix/store -type d -path '*/bin' | paste -sd: -
 export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
+echo "PATH: $PATH"
 
 # Start Podman machine if not running
 if ! podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null | grep -q 'running'; then

--- a/docker/build/movement/entry.sh
+++ b/docker/build/movement/entry.sh
@@ -3,9 +3,9 @@
 set -e
 
 echo "Debugging nix store..."
-ls -al /nix/store
-find /nix/store -type d -path '*/bin' | paste -sd: -
-export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
+ls -al /nix-bin/store
+find /nix-bin/store -type d -path '*/bin' | paste -sd: -
+export PATH="/nix-bin/store:$(find /nix-bin/store -type d -path '*/bin' | paste -sd: -):$PATH"
 echo "PATH: $PATH"
 
 # Start Podman machine if not running

--- a/docker/build/movement/entry.sh
+++ b/docker/build/movement/entry.sh
@@ -8,24 +8,57 @@ find /nix/store -type d -path '*/bin' | paste -sd: -
 export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
 echo "PATH: $PATH"
 
-# Check if podman machine exists and is running
-if ! podman machine inspect podman-machine-default &>/dev/null; then
-    echo "Initializing podman machine..."
-    podman machine init
-    podman machine start
-elif ! podman machine inspect podman-machine-default --format '{{.State}}' | grep -q 'running'; then
-    echo "Starting podman machine..."
-    podman machine start
+# Validate DOCKER_HOST environment variable and socket connectivity
+echo "Validating container management setup..."
+
+if [ -z "$DOCKER_HOST" ]; then
+    echo "ERROR: DOCKER_HOST environment variable is not set"
+    echo "Please set DOCKER_HOST to point to a valid Docker/Podman socket"
+    echo "Examples:"
+    echo "  - unix:///var/run/docker.sock (for Docker)"
+    echo "  - unix:///run/user/1000/podman/podman.sock (for Podman)"
+    exit 1
 fi
 
-# Find the actual podman socket location
-PODMAN_SOCKET=$(find /tmp/nix-shell.*/podman -name "podman-machine-default-api.sock" -type s 2>/dev/null | head -n 1)
-if [ -n "$PODMAN_SOCKET" ]; then
-    export DOCKER_HOST="unix://$PODMAN_SOCKET"
-    echo "Set DOCKER_HOST to Podman socket: $DOCKER_HOST"
+echo "DOCKER_HOST is set to: $DOCKER_HOST"
+
+# Extract socket path from DOCKER_HOST
+if [[ "$DOCKER_HOST" == unix://* ]]; then
+    SOCKET_PATH="${DOCKER_HOST#unix://}"
+    echo "Socket path: $SOCKET_PATH"
+    
+    # Check if socket file exists and is accessible
+    if [ ! -S "$SOCKET_PATH" ]; then
+        echo "ERROR: Socket file does not exist or is not accessible: $SOCKET_PATH"
+        echo "Please ensure the container runtime socket is available and mounted"
+        exit 1
+    fi
+    
+    # Test socket connectivity by trying to list containers
+    echo "Testing socket connectivity..."
+    if command -v docker &> /dev/null; then
+        if docker ps &> /dev/null; then
+            echo "✓ Docker socket is working - can list containers"
+        else
+            echo "✗ Docker socket test failed"
+            exit 1
+        fi
+    elif command -v podman &> /dev/null; then
+        if podman ps &> /dev/null; then
+            echo "✓ Podman socket is working - can list containers"
+        else
+            echo "✗ Podman socket test failed"
+            exit 1
+        fi
+    else
+        echo "WARNING: Neither docker nor podman command found, but socket exists"
+        echo "Socket validation passed, but container management may not work"
+    fi
 else
-    echo "Warning: Could not find Podman socket"
+    echo "WARNING: DOCKER_HOST is not a unix socket, container management may not work"
+    echo "Current DOCKER_HOST: $DOCKER_HOST"
 fi
 
-echo "Podman socket ready. Launching application..."
+echo "Container management setup validated successfully!"
+echo "Launching application..."
 exec /app/movement "$@"

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p /run/user/1000/podman && \
 
 # Copy runtime bootstrap script
 COPY docker/build/mtma/entry.sh /app/entry.sh
-RUN chmod +x /app/entry.sh
+RUN chmod +x /app/entry.sh && chown mtma:mtma /app/entry.sh
 
 # Switch to non-root user
 USER mtma

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -28,6 +28,7 @@ RUN adduser -u 1000 -D -s /bin/bash mtma
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/mtma /app/mtma
 COPY --from=builder /tmp/runtime/nix/store /nix/store
+COPY --dereference --from=builder /nix/store/ /nix/store/
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -9,9 +9,27 @@ WORKDIR /tmp/build
 # Set build to docker to skip the podman initilization while opening the flake
 ENV BUILD=docker
 
-# Build the Rust application
+RUN nix --extra-experimental-features "nix-command flakes" \
+        develop --command bash -c "mkdir -p  /tmp/executables"
+
+# Copy celestia-appd to /tmp/executables
+RUN nix --extra-experimental-features "nix-command flakes" \
+        develop --command bash -c "cp \$(which podman) /tmp/executables/podman"
+
+        # Build the Rust application
 RUN nix --extra-experimental-features "nix-command flakes" \
         develop .#docker-build --command bash -c "cargo build --release -p mtma"
+
+
+RUN rust_binary="./target/release/mtma"; dest_dir="/tmp/runtime"; \
+    mkdir -p "$dest_dir"; ldd "$rust_binary" | awk '{print $3}' | \
+    grep '^/' | xargs -I {} dirname {} | sort | uniq | xargs -I {} \
+    bash -c 'mkdir -p "$0/$1" && rsync -a --copy-links "$1/" "$0/$1/"' "$dest_dir" {}
+
+RUN rust_binary="/tmp/executables/podman"; dest_dir="/tmp/runtime"; \
+    mkdir -p "$dest_dir"; ldd "$rust_binary" | awk '{print $3}' | \
+    grep '^/' | xargs -I {} dirname {} | sort | uniq | xargs -I {} \
+    bash -c 'mkdir -p "$0/$1" && rsync -a --copy-links "$1/" "$0/$1/"' "$dest_dir" {}
 
 FROM alpine:3.22.0
 
@@ -23,6 +41,9 @@ RUN adduser -u 1000 -D -s /bin/bash mtma
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/mtma /app/mtma
 COPY --from=builder /nix/store /nix/store
+
+# copy executables
+COPY --from=builder /tmp/executables/podman /usr/local/bin/podman
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -20,6 +20,8 @@ RUN rust_binary="./target/release/mtma"; dest_dir="/tmp/runtime"; \
 
 FROM alpine:3.22.0
 
+RUN apk add --no-cache bash
+
 # Create non-root user
 RUN adduser -u 1000 -D -s /bin/bash mtma
 

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -28,7 +28,7 @@ RUN adduser -u 1000 -D -s /bin/bash mtma
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/mtma /app/mtma
 COPY --from=builder /tmp/runtime/nix/store /nix/store
-COPY --dereference --from=builder /nix/store/ /nix/store/
+COPY --from=builder /nix/store/ /nix/store/
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -28,7 +28,6 @@ RUN adduser -u 1000 -D -s /bin/bash mtma
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/mtma /app/mtma
 COPY --from=builder /tmp/runtime/nix/store /nix/store
-COPY --from=builder /tmp/runtime/nix/var/nix/profiles/default/bin /nix/var/nix/profiles/default/bin
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -12,11 +12,12 @@ ENV BUILD=docker
 RUN nix --extra-experimental-features "nix-command flakes" \
         develop --command bash -c "mkdir -p  /tmp/executables"
 
-# Copy celestia-appd to /tmp/executables
 RUN nix --extra-experimental-features "nix-command flakes" \
         develop --command bash -c "cp \$(which podman) /tmp/executables/podman"
 
-        # Build the Rust application
+RUN nix --extra-experimental-features "nix-command flakes" \
+        develop --command bash -c "cp \$(which docker) /tmp/executables/docker"
+
 RUN nix --extra-experimental-features "nix-command flakes" \
         develop .#docker-build --command bash -c "cargo build --release --bin mtma"
 
@@ -44,15 +45,16 @@ COPY --from=builder /nix/store /nix/store
 
 # copy executables
 COPY --from=builder /tmp/executables/podman /usr/local/bin/podman
+COPY --from=builder /tmp/executables/docker /usr/local/bin/docker
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"
 ENV XDG_RUNTIME_DIR="/run/user/1000"
 ENV TMPDIR="/tmp"
-ENV DOCKER_HOST="unix:///run/user/1000/podman/podman-machine-default-api.sock"
+# DOCKER_HOST will be set at runtime or passed in via environment
 
 # Create required runtime dirs with proper ownership
-RUN mkdir -p /run/user/1000/podman && \
+RUN mkdir -p /run/user/1000 && \
     chown -R mtma:mtma /run/user/1000 /app /nix
 
 # Copy runtime bootstrap script

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -18,7 +18,7 @@ RUN nix --extra-experimental-features "nix-command flakes" \
 
         # Build the Rust application
 RUN nix --extra-experimental-features "nix-command flakes" \
-        develop .#docker-build --command bash -c "cargo build --release -p mtma"
+        develop .#docker-build --command bash -c "cargo build --release --bin mtma"
 
 
 RUN rust_binary="./target/release/mtma"; dest_dir="/tmp/runtime"; \

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -13,11 +13,6 @@ ENV BUILD=docker
 RUN nix --extra-experimental-features "nix-command flakes" \
         develop .#docker-build --command bash -c "cargo build --release -p mtma"
 
-RUN rust_binary="./target/release/mtma"; dest_dir="/tmp/runtime"; \
-    mkdir -p "$dest_dir"; ldd "$rust_binary" | awk '{print $3}' | \
-    grep '^/' | xargs -I {} dirname {} | sort | uniq | xargs -I {} \
-    bash -c 'mkdir -p "$0/$1" && rsync -a --copy-links "$1/" "$0/$1/"' "$dest_dir" {}
-
 FROM alpine:3.22.0
 
 RUN apk add --no-cache bash
@@ -27,8 +22,7 @@ RUN adduser -u 1000 -D -s /bin/bash mtma
 
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/mtma /app/mtma
-COPY --from=builder /tmp/runtime/nix/store /nix/store
-COPY --from=builder /nix/store/ /nix-bin/store/
+COPY --from=builder /nix/store /nix/store
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -28,7 +28,7 @@ RUN adduser -u 1000 -D -s /bin/bash mtma
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/mtma /app/mtma
 COPY --from=builder /tmp/runtime/nix/store /nix/store
-COPY --from=builder /nix/store/ /nix/store/
+COPY --from=builder /nix/store/ /nix-bin/store/
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/mtma/Dockerfile
+++ b/docker/build/mtma/Dockerfile
@@ -26,6 +26,7 @@ RUN adduser -u 1000 -D -s /bin/bash mtma
 # Copy binary and runtime deps
 COPY --from=builder /tmp/build/target/release/mtma /app/mtma
 COPY --from=builder /tmp/runtime/nix/store /nix/store
+COPY --from=builder /tmp/runtime/nix/var/nix/profiles/default/bin /nix/var/nix/profiles/default/bin
 
 # Environment setup
 ENV PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/docker/build/mtma/entry.sh
+++ b/docker/build/mtma/entry.sh
@@ -22,43 +22,6 @@ fi
 
 echo "DOCKER_HOST is set to: $DOCKER_HOST"
 
-# Extract socket path from DOCKER_HOST
-if [[ "$DOCKER_HOST" == unix://* ]]; then
-    SOCKET_PATH="${DOCKER_HOST#unix://}"
-    echo "Socket path: $SOCKET_PATH"
-    
-    # Check if socket file exists and is accessible
-    if [ ! -S "$SOCKET_PATH" ]; then
-        echo "ERROR: Socket file does not exist or is not accessible: $SOCKET_PATH"
-        echo "Please ensure the container runtime socket is available and mounted"
-        exit 1
-    fi
-    
-    # Test socket connectivity by trying to list containers
-    echo "Testing socket connectivity..."
-    if command -v docker &> /dev/null; then
-        if docker ps &> /dev/null; then
-            echo "✓ Docker socket is working - can list containers"
-        else
-            echo "✗ Docker socket test failed"
-            exit 1
-        fi
-    elif command -v podman &> /dev/null; then
-        if podman ps &> /dev/null; then
-            echo "✓ Podman socket is working - can list containers"
-        else
-            echo "✗ Podman socket test failed"
-            exit 1
-        fi
-    else
-        echo "WARNING: Neither docker nor podman command found, but socket exists"
-        echo "Socket validation passed, but container management may not work"
-    fi
-else
-    echo "WARNING: DOCKER_HOST is not a unix socket, container management may not work"
-    echo "Current DOCKER_HOST: $DOCKER_HOST"
-fi
-
 echo "Container management setup validated successfully!"
 echo "Launching application..."
 exec /app/mtma "$@"

--- a/docker/build/mtma/entry.sh
+++ b/docker/build/mtma/entry.sh
@@ -3,9 +3,9 @@
 set -e
 
 echo "Debugging nix store..."
-ls -al /nix-bin/store
-find /nix-bin/store -type d -path '*/bin' | paste -sd: -
-export PATH="/nix-bin/store:$(find /nix-bin/store -type d -path '*/bin' | paste -sd: -):$PATH"
+ls -al /nix/store
+find /nix/store -type d -path '*/bin' | paste -sd: -
+export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
 echo "PATH: $PATH"
 
 # Start Podman machine if not running

--- a/docker/build/mtma/entry.sh
+++ b/docker/build/mtma/entry.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+find /nix/store -type d -path '*/bin' | paste -sd: -
+export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
+
 # Start Podman machine if not running
 if ! podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null | grep -q 'running'; then
     echo "Starting podman machine..."

--- a/docker/build/mtma/entry.sh
+++ b/docker/build/mtma/entry.sh
@@ -2,8 +2,11 @@
 
 set -e
 
+echo "Debugging nix store..."
+ls -al /nix/store
 find /nix/store -type d -path '*/bin' | paste -sd: -
 export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
+echo "PATH: $PATH"
 
 # Start Podman machine if not running
 if ! podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null | grep -q 'running'; then

--- a/docker/build/mtma/entry.sh
+++ b/docker/build/mtma/entry.sh
@@ -8,24 +8,57 @@ find /nix/store -type d -path '*/bin' | paste -sd: -
 export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
 echo "PATH: $PATH"
 
-# Check if podman machine exists and is running
-if ! podman machine inspect podman-machine-default &>/dev/null; then
-    echo "Initializing podman machine..."
-    podman machine init
-    podman machine start
-elif ! podman machine inspect podman-machine-default --format '{{.State}}' | grep -q 'running'; then
-    echo "Starting podman machine..."
-    podman machine start
+# Validate DOCKER_HOST environment variable and socket connectivity
+echo "Validating container management setup..."
+
+if [ -z "$DOCKER_HOST" ]; then
+    echo "ERROR: DOCKER_HOST environment variable is not set"
+    echo "Please set DOCKER_HOST to point to a valid Docker/Podman socket"
+    echo "Examples:"
+    echo "  - unix:///var/run/docker.sock (for Docker)"
+    echo "  - unix:///run/user/1000/podman/podman.sock (for Podman)"
+    exit 1
 fi
 
-# Find the actual podman socket location
-PODMAN_SOCKET=$(find /tmp/nix-shell.*/podman -name "podman-machine-default-api.sock" -type s 2>/dev/null | head -n 1)
-if [ -n "$PODMAN_SOCKET" ]; then
-    export DOCKER_HOST="unix://$PODMAN_SOCKET"
-    echo "Set DOCKER_HOST to Podman socket: $DOCKER_HOST"
+echo "DOCKER_HOST is set to: $DOCKER_HOST"
+
+# Extract socket path from DOCKER_HOST
+if [[ "$DOCKER_HOST" == unix://* ]]; then
+    SOCKET_PATH="${DOCKER_HOST#unix://}"
+    echo "Socket path: $SOCKET_PATH"
+    
+    # Check if socket file exists and is accessible
+    if [ ! -S "$SOCKET_PATH" ]; then
+        echo "ERROR: Socket file does not exist or is not accessible: $SOCKET_PATH"
+        echo "Please ensure the container runtime socket is available and mounted"
+        exit 1
+    fi
+    
+    # Test socket connectivity by trying to list containers
+    echo "Testing socket connectivity..."
+    if command -v docker &> /dev/null; then
+        if docker ps &> /dev/null; then
+            echo "✓ Docker socket is working - can list containers"
+        else
+            echo "✗ Docker socket test failed"
+            exit 1
+        fi
+    elif command -v podman &> /dev/null; then
+        if podman ps &> /dev/null; then
+            echo "✓ Podman socket is working - can list containers"
+        else
+            echo "✗ Podman socket test failed"
+            exit 1
+        fi
+    else
+        echo "WARNING: Neither docker nor podman command found, but socket exists"
+        echo "Socket validation passed, but container management may not work"
+    fi
 else
-    echo "Warning: Could not find Podman socket"
+    echo "WARNING: DOCKER_HOST is not a unix socket, container management may not work"
+    echo "Current DOCKER_HOST: $DOCKER_HOST"
 fi
 
-echo "Podman socket ready. Launching application..."
+echo "Container management setup validated successfully!"
+echo "Launching application..."
 exec /app/mtma "$@"

--- a/docker/build/mtma/entry.sh
+++ b/docker/build/mtma/entry.sh
@@ -3,9 +3,9 @@
 set -e
 
 echo "Debugging nix store..."
-ls -al /nix/store
-find /nix/store -type d -path '*/bin' | paste -sd: -
-export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
+ls -al /nix-bin/store
+find /nix-bin/store -type d -path '*/bin' | paste -sd: -
+export PATH="/nix-bin/store:$(find /nix-bin/store -type d -path '*/bin' | paste -sd: -):$PATH"
 echo "PATH: $PATH"
 
 # Start Podman machine if not running

--- a/docker/build/mtma/entry.sh
+++ b/docker/build/mtma/entry.sh
@@ -8,24 +8,24 @@ find /nix/store -type d -path '*/bin' | paste -sd: -
 export PATH="/nix/store:$(find /nix/store -type d -path '*/bin' | paste -sd: -):$PATH"
 echo "PATH: $PATH"
 
-# Start Podman machine if not running
-if ! podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null | grep -q 'running'; then
+# Check if podman machine exists and is running
+if ! podman machine inspect podman-machine-default &>/dev/null; then
+    echo "Initializing podman machine..."
+    podman machine init
+    podman machine start
+elif ! podman machine inspect podman-machine-default --format '{{.State}}' | grep -q 'running'; then
     echo "Starting podman machine..."
     podman machine start
 fi
 
-# Wait for podman socket
-timeout=30
-elapsed=0
-while [ ! -S "$DOCKER_HOST" ]; do
-    echo "Waiting for podman socket..."
-    sleep 1
-    elapsed=$((elapsed + 1))
-    if [ "$elapsed" -ge "$timeout" ]; then
-        echo "Timed out waiting for podman socket."
-        exit 1
-    fi
-done
+# Find the actual podman socket location
+PODMAN_SOCKET=$(find /tmp/nix-shell.*/podman -name "podman-machine-default-api.sock" -type s 2>/dev/null | head -n 1)
+if [ -n "$PODMAN_SOCKET" ]; then
+    export DOCKER_HOST="unix://$PODMAN_SOCKET"
+    echo "Set DOCKER_HOST to Podman socket: $DOCKER_HOST"
+else
+    echo "Warning: Could not find Podman socket"
+fi
 
 echo "Podman socket ready. Launching application..."
 exec /app/mtma "$@"

--- a/scripts/docker/build-push-container.sh
+++ b/scripts/docker/build-push-container.sh
@@ -44,7 +44,7 @@ if [ "$debug" = true ]; then
 fi
 
 # Get git info
-commit_hash=$(git rev-parse HEAD | cut -c1-7)
+commit_hash=$(git rev-parse HEAD)
 branch_name=$(git rev-parse --abbrev-ref HEAD)
 sanitized_branch_name=${branch_name//\//.}
 is_tag=false

--- a/scripts/docker/build-push-manifest.sh
+++ b/scripts/docker/build-push-manifest.sh
@@ -44,7 +44,7 @@ if [ "$debug" = true ]; then
 fi
 
 # Get git info
-commit_hash=$(git rev-parse HEAD | cut -c1-7)
+commit_hash=$(git rev-parse HEAD)
 branch_name=$(git rev-parse --abbrev-ref HEAD)
 sanitized_branch_name=${branch_name//\//.}
 is_tag=false


### PR DESCRIPTION
# Summary
Adds provisional `--help` checks for containers. 

> [!NOTE]
> This primarily serves to introduce the container check action structure. More intensive checks would be structured in later PRs. 

> [!WARNING]
> The current Podman-in-Podman setup is flaky. The intent is to migrate to a fixed version of this setup in later PRs and let this serve as a demonstration of some of the issues encountered thusfar. 